### PR TITLE
Fixed bamboo stick exploit

### DIFF
--- a/src/main/generated/data/twigs/recipes/stripped_bamboo_planks.json
+++ b/src/main/generated/data/twigs/recipes/stripped_bamboo_planks.json
@@ -1,5 +1,6 @@
 {
     "type": "minecraft:crafting_shaped",
+    "group": "planks",
     "pattern": [
         "##",
         "##"

--- a/src/main/generated/data/twigs/recipes/stripped_bamboo_planks.json
+++ b/src/main/generated/data/twigs/recipes/stripped_bamboo_planks.json
@@ -1,13 +1,16 @@
 {
-  "type": "minecraft:crafting_shapeless",
-  "group": "planks",
-  "ingredients": [
-    {
-      "item": "twigs:stripped_bamboo"
+    "type": "minecraft:crafting_shaped",
+    "pattern": [
+        "##",
+        "##"
+    ],
+    "key": {
+        "#": {
+            "item": "twigs:stripped_bamboo"
+        }
+    },
+    "result": {
+        "item": "twigs:stripped_bamboo_planks",
+        "count": 1
     }
-  ],
-  "result": {
-    "count": 4,
-    "item": "twigs:stripped_bamboo_planks"
-  }
 }


### PR DESCRIPTION
Before: One stripped bamboo equals 4 planks which can be used to make 8 sticks. Two non-stripped bamboo is needed to make one stick. So you are making 16x the amount of sticks by just stripping the bamboo in a grindstone.

After: You now would need four stripped bamboo to make one plank. This means that if you strip the bamboo, the number of sticks you would make by creating sticks with stripped bamboo planks would be the same.

Note: I hope that I edited the correct file. 